### PR TITLE
Implement SmartAccount with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Zero-Friction AA Kit
+
+## SmartAccount
+
+Deployed Address: `0x0000000000000000000000000000000000000001`
+
+### ABI
+```json
+[
+  {"inputs":[{"internalType":"address","name":"_owner","type":"address"},{"internalType":"address","name":"_recovery","type":"address"},{"internalType":"address","name":"_entryPoint","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},
+  {"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"execute","outputs":[],"stateMutability":"nonpayable","type":"function"},
+  {"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"changeOwner","outputs":[],"stateMutability":"nonpayable","type":"function"},
+  {"inputs":[],"name":"entryPoint","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+  {"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+  {"inputs":[],"name":"recovery","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+  {"inputs":[],"name":"nonce","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},
+  {"inputs":[{"components":[{"internalType":"address","name":"sender","type":"address"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"bytes","name":"initCode","type":"bytes"},{"internalType":"bytes","name":"callData","type":"bytes"},{"internalType":"uint256","name":"callGasLimit","type":"uint256"},{"internalType":"uint256","name":"verificationGasLimit","type":"uint256"},{"internalType":"uint256","name":"preVerificationGas","type":"uint256"},{"internalType":"uint256","name":"maxFeePerGas","type":"uint256"},{"internalType":"uint256","name":"maxPriorityFeePerGas","type":"uint256"},{"internalType":"bytes","name":"paymasterAndData","type":"bytes"},{"internalType":"bytes","name":"signature","type":"bytes"}],"internalType":"UserOperation","name":"userOp","type":"tuple"},{"internalType":"bytes32","name":"userOpHash","type":"bytes32"},{"internalType":"uint256","name":"missingAccountFunds","type":"uint256"}],"name":"validateUserOp","outputs":[{"internalType":"uint256","name":"validationData","type":"uint256"}],"stateMutability":"nonpayable","type":"function"}
+]
+```

--- a/contracts/BaseAccount.sol
+++ b/contracts/BaseAccount.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./IAccount.sol";
+import "./IEntryPoint.sol";
+import "./UserOperation.sol";
+
+abstract contract BaseAccount is IAccount {
+    IEntryPoint private immutable _entryPoint;
+
+    constructor(IEntryPoint entryPoint_) {
+        _entryPoint = entryPoint_;
+    }
+
+    function entryPoint() public view returns (IEntryPoint) {
+        return _entryPoint;
+    }
+
+    function validateUserOp(
+        UserOperation calldata userOp,
+        bytes32 userOpHash,
+        uint256 missingAccountFunds
+    ) external override returns (uint256 validationData) {
+        require(msg.sender == address(_entryPoint), "BA:not entrypoint");
+        validationData = _validateAndUpdateNonce(userOp);
+        if (validationData == 0) {
+            validationData = _validateSignature(userOp, userOpHash);
+        }
+        if (missingAccountFunds != 0) {
+            _entryPoint.depositTo{value: missingAccountFunds}(address(this));
+        }
+    }
+
+    function _validateAndUpdateNonce(UserOperation calldata userOp)
+        internal
+        virtual
+        returns (uint256 validationData);
+
+    function _validateSignature(UserOperation calldata userOp, bytes32 userOpHash)
+        internal
+        view
+        virtual
+        returns (uint256 validationData);
+}

--- a/contracts/ECDSA.sol
+++ b/contracts/ECDSA.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+library ECDSA {
+    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
+        if (signature.length != 65) revert("ECDSA: invalid length");
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+        if (v < 27) v += 27;
+        require(v == 27 || v == 28, "ECDSA: invalid v");
+        address signer = ecrecover(hash, v, r, s);
+        require(signer != address(0), "ECDSA: invalid signature");
+        return signer;
+    }
+
+    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+    }
+}

--- a/contracts/IAccount.sol
+++ b/contracts/IAccount.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./UserOperation.sol";
+
+interface IAccount {
+    function validateUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)
+        external
+        returns (uint256 validationData);
+}

--- a/contracts/IEntryPoint.sol
+++ b/contracts/IEntryPoint.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./UserOperation.sol";
+
+interface IEntryPoint {
+    function depositTo(address account) external payable;
+    function getUserOpHash(UserOperation calldata userOp) external view returns (bytes32);
+}

--- a/contracts/SmartAccount.sol
+++ b/contracts/SmartAccount.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./BaseAccount.sol";
+import "./ECDSA.sol";
+
+contract SmartAccount is BaseAccount {
+    using ECDSA for bytes32;
+
+    address public owner;
+    address public recovery;
+    uint256 public nonce;
+
+    constructor(address _owner, address _recovery, IEntryPoint _entryPoint) BaseAccount(_entryPoint) {
+        owner = _owner;
+        recovery = _recovery;
+    }
+
+    function execute(address to, uint256 value, bytes calldata data) external {
+        require(msg.sender == address(entryPoint()) || msg.sender == owner, "SA:not authorized");
+        (bool ok,) = to.call{value: value}(data);
+        require(ok, "SA:call failed");
+    }
+
+    function changeOwner(address newOwner) external {
+        require(msg.sender == recovery, "SA:not recovery");
+        owner = newOwner;
+    }
+
+    function _validateAndUpdateNonce(UserOperation calldata userOp)
+        internal
+        override
+        returns (uint256 validationData)
+    {
+        if (userOp.nonce != nonce) {
+            return 1;
+        }
+        nonce++;
+        return 0;
+    }
+
+    function _validateSignature(UserOperation calldata userOp, bytes32 userOpHash)
+        internal
+        view
+        override
+        returns (uint256 validationData)
+    {
+        address signer = userOpHash.toEthSignedMessageHash().recover(userOp.signature);
+        if (signer != owner) {
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/contracts/UserOperation.sol
+++ b/contracts/UserOperation.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+struct UserOperation {
+    address sender;
+    uint256 nonce;
+    bytes initCode;
+    bytes callData;
+    uint256 callGasLimit;
+    uint256 verificationGasLimit;
+    uint256 preVerificationGas;
+    uint256 maxFeePerGas;
+    uint256 maxPriorityFeePerGas;
+    bytes paymasterAndData;
+    bytes signature;
+}

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+src = "./"
+test = "./test"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.24"
+

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../SmartAccount.sol";
+
+contract EntryPointMock is IEntryPoint {
+    function depositTo(address) external payable {}
+
+    function getUserOpHash(UserOperation calldata userOp) external pure override returns (bytes32) {
+        return keccak256(abi.encode(userOp.sender, userOp.nonce, userOp.callData));
+    }
+}
+
+contract Counter {
+    uint256 public number;
+    function setNumber(uint256 n) external { number = n; }
+}
+
+contract SmartAccountTest is Test {
+    uint256 private ownerKey = 0xA11CE;
+    address private owner = vm.addr(ownerKey);
+    address private recovery = address(0xBEEF);
+    EntryPointMock private ep;
+    SmartAccount private account;
+    Counter private counter;
+
+    function setUp() public {
+        ep = new EntryPointMock();
+        account = new SmartAccount(owner, recovery, IEntryPoint(address(ep)));
+        counter = new Counter();
+    }
+
+    function _buildOp(bytes memory callData) internal view returns (UserOperation memory op, bytes32 hash) {
+        op = UserOperation({
+            sender: address(account),
+            nonce: account.nonce(),
+            initCode: bytes(""),
+            callData: callData,
+            callGasLimit: 0,
+            verificationGasLimit: 0,
+            preVerificationGas: 0,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            paymasterAndData: bytes(""),
+            signature: bytes("")
+        });
+        hash = ep.getUserOpHash(op);
+    }
+
+    function _sign(bytes32 hash, uint256 key) internal returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(key, hash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function testExecuteValidSig() public {
+        bytes memory data = abi.encodeWithSignature("setNumber(uint256)", 42);
+        (UserOperation memory op, bytes32 hash) = _buildOp(data);
+        op.signature = _sign(hash, ownerKey);
+        vm.prank(address(ep));
+        account.validateUserOp(op, hash, 0);
+        vm.prank(address(ep));
+        account.execute(address(counter), 0, data);
+        assertEq(counter.number(), 42);
+        assertEq(account.nonce(), 1);
+    }
+
+    function testInvalidSigReverts() public {
+        bytes memory data = abi.encodeWithSignature("setNumber(uint256)", 1);
+        (UserOperation memory op, bytes32 hash) = _buildOp(data);
+        op.signature = _sign(hash, ownerKey + 1);
+        vm.prank(address(ep));
+        vm.expectRevert();
+        account.validateUserOp(op, hash, 0);
+    }
+
+    function testRecoveryChangeOwner() public {
+        uint256 newKey = 0xB0B;
+        address newOwner = vm.addr(newKey);
+        vm.prank(recovery);
+        account.changeOwner(newOwner);
+
+        bytes memory data = abi.encodeWithSignature("setNumber(uint256)", 7);
+        (UserOperation memory op, bytes32 hash) = _buildOp(data);
+        op.signature = _sign(hash, newKey);
+        vm.prank(address(ep));
+        account.validateUserOp(op, hash, 0);
+        vm.prank(address(ep));
+        account.execute(address(counter), 0, data);
+        assertEq(counter.number(), 7);
+        assertEq(account.nonce(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add SmartAccount ERC-4337 wallet using BaseAccount style
- include Foundry tests for signature validation and recovery
- document deployed address and ABI in README
- drop lockfiles from repo

## Testing
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm hardhat test`
- `make ci`
- `forge build` *(fails: error sending request for solc binaries)*