### PR TITLE
Implement basic Paymaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ Deployed Address: `0x0000000000000000000000000000000000000001`
   {"inputs":[{"components":[{"internalType":"address","name":"sender","type":"address"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"bytes","name":"initCode","type":"bytes"},{"internalType":"bytes","name":"callData","type":"bytes"},{"internalType":"uint256","name":"callGasLimit","type":"uint256"},{"internalType":"uint256","name":"verificationGasLimit","type":"uint256"},{"internalType":"uint256","name":"preVerificationGas","type":"uint256"},{"internalType":"uint256","name":"maxFeePerGas","type":"uint256"},{"internalType":"uint256","name":"maxPriorityFeePerGas","type":"uint256"},{"internalType":"bytes","name":"paymasterAndData","type":"bytes"},{"internalType":"bytes","name":"signature","type":"bytes"}],"internalType":"UserOperation","name":"userOp","type":"tuple"},{"internalType":"bytes32","name":"userOpHash","type":"bytes32"},{"internalType":"uint256","name":"missingAccountFunds","type":"uint256"}],"name":"validateUserOp","outputs":[{"internalType":"uint256","name":"validationData","type":"uint256"}],"stateMutability":"nonpayable","type":"function"}
 ]
 ```
+
+## Paymaster architecture
+ZfaPaymaster builds on Infinitism's BasePaymaster. An owner controls a whitelist
+of dApps and may fund the paymaster using `depositToEntryPoint`. The paymaster
+sponsors operations only when the calling dApp (`tx.origin`) is approved. After
+`postOp`, any ETH returned by the EntryPoint is re-deposited up to `maxRefundWei`
+and a `GasSponsored` event logs the user and actual gas cost.

--- a/contracts/BasePaymaster.sol
+++ b/contracts/BasePaymaster.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./IPaymaster.sol";
+import "./IEntryPoint.sol";
+import "./UserOperation.sol";
+
+abstract contract BasePaymaster is IPaymaster {
+    IEntryPoint private immutable _entryPoint;
+
+    constructor(IEntryPoint anEntryPoint) {
+        _entryPoint = anEntryPoint;
+    }
+
+    function entryPoint() public view returns (IEntryPoint) {
+        return _entryPoint;
+    }
+
+    function deposit() external payable {
+        _entryPoint.depositTo{value: msg.value}(address(this));
+    }
+
+    modifier onlyEntryPoint() {
+        require(msg.sender == address(_entryPoint), "BP:not entrypoint");
+        _;
+    }
+
+    function validatePaymasterUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 maxCost)
+        external
+        override
+        onlyEntryPoint
+        returns (bytes memory context, uint256 validationData)
+    {
+        return _validatePaymasterUserOp(userOp, userOpHash, maxCost);
+    }
+
+    function _validatePaymasterUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 maxCost)
+        internal
+        virtual
+        returns (bytes memory context, uint256 validationData);
+
+    function postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost)
+        external
+        payable
+        override
+        onlyEntryPoint
+    {
+        _postOp(mode, context, actualGasCost);
+    }
+
+    function _postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost) internal virtual;
+}

--- a/contracts/IPaymaster.sol
+++ b/contracts/IPaymaster.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./UserOperation.sol";
+
+interface IPaymaster {
+    enum PostOpMode {
+        opSucceeded,
+        opReverted,
+        postOpReverted
+    }
+
+    function validatePaymasterUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 maxCost)
+        external
+        returns (bytes memory context, uint256 validationData);
+
+    function postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost) external payable;
+}

--- a/contracts/ZfaPaymaster.sol
+++ b/contracts/ZfaPaymaster.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./BasePaymaster.sol";
+
+contract ZfaPaymaster is BasePaymaster {
+    mapping(address => bool) public whitelistedDapps;
+    address public owner;
+    uint256 public immutable maxRefundWei;
+    address public lastUser;
+    uint256 public lastAmount;
+
+    event GasSponsored(address user, uint256 amountWei);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "ZP:not owner");
+        _;
+    }
+
+    constructor(IEntryPoint entryPoint, address _owner, uint256 _maxRefundWei) BasePaymaster(entryPoint) {
+        owner = _owner;
+        maxRefundWei = _maxRefundWei;
+    }
+
+    function addToWhitelist(address dapp) external onlyOwner {
+        whitelistedDapps[dapp] = true;
+    }
+
+    function removeFromWhitelist(address dapp) external onlyOwner {
+        whitelistedDapps[dapp] = false;
+    }
+
+    function depositToEntryPoint() external payable onlyOwner {
+        entryPoint().depositTo{value: msg.value}(address(this));
+    }
+
+    function _validatePaymasterUserOp(UserOperation calldata userOp, bytes32, uint256) internal override returns (bytes memory context, uint256 validationData) {
+        require(whitelistedDapps[tx.origin], "ZP:not whitelisted");
+        return (abi.encode(userOp.sender), 0);
+    }
+
+    function _postOp(PostOpMode, bytes calldata context, uint256 actualGasCost) internal override {
+        uint256 refund = msg.value > maxRefundWei ? maxRefundWei : msg.value;
+        if (refund > 0) {
+            entryPoint().depositTo{value: refund}(address(this));
+        }
+        address user = abi.decode(context, (address));
+        lastUser = user;
+        lastAmount = actualGasCost;
+        emit GasSponsored(user, actualGasCost);
+    }
+
+    receive() external payable {}
+}

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -14,7 +14,10 @@ contract EntryPointMock is IEntryPoint {
 
 contract Counter {
     uint256 public number;
-    function setNumber(uint256 n) external { number = n; }
+
+    function setNumber(uint256 n) external {
+        number = n;
+    }
 }
 
 contract SmartAccountTest is Test {
@@ -70,8 +73,8 @@ contract SmartAccountTest is Test {
         (UserOperation memory op, bytes32 hash) = _buildOp(data);
         op.signature = _sign(hash, ownerKey + 1);
         vm.prank(address(ep));
-        vm.expectRevert();
-        account.validateUserOp(op, hash, 0);
+        uint256 validation = account.validateUserOp(op, hash, 0);
+        assertEq(validation, 1);
     }
 
     function testRecoveryChangeOwner() public {

--- a/contracts/test/ZfaPaymaster.t.sol
+++ b/contracts/test/ZfaPaymaster.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../ZfaPaymaster.sol";
+
+contract EntryPointMock is IEntryPoint {
+    mapping(address => uint256) public deposits;
+
+    function depositTo(address account) external payable override {
+        deposits[account] += msg.value;
+    }
+
+    function getUserOpHash(UserOperation calldata userOp) external pure override returns (bytes32) {
+        return keccak256(abi.encode(userOp.sender, userOp.nonce));
+    }
+
+    function simulateValidate(address paymaster, UserOperation calldata op, uint256 maxCost)
+        external
+        returns (bytes memory context, uint256 validationData)
+    {
+        return IPaymaster(paymaster).validatePaymasterUserOp(op, bytes32(0), maxCost);
+    }
+
+    function simulatePostOp(address paymaster, bytes calldata context, uint256 actualGasCost) external payable {
+        IPaymaster(paymaster).postOp{value: msg.value}(IPaymaster.PostOpMode.opSucceeded, context, actualGasCost);
+    }
+}
+
+contract ZfaPaymasterTest is Test {
+    EntryPointMock private ep;
+    ZfaPaymaster private paymaster;
+    address private dapp = address(0xAA);
+    address private user = address(0xBB);
+    address private originAddr;
+
+    function setUp() public {
+        ep = new EntryPointMock();
+        paymaster = new ZfaPaymaster(IEntryPoint(address(ep)), address(this), 0.5 ether);
+        originAddr = tx.origin;
+    }
+
+    function _buildOp() internal view returns (UserOperation memory op) {
+        op = UserOperation({
+            sender: user,
+            nonce: 0,
+            initCode: bytes(""),
+            callData: bytes(""),
+            callGasLimit: 0,
+            verificationGasLimit: 0,
+            preVerificationGas: 0,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            paymasterAndData: bytes(""),
+            signature: bytes("")
+        });
+    }
+
+    function testWhitelistedCallSponsored() public {
+        paymaster.addToWhitelist(originAddr);
+        UserOperation memory op = _buildOp();
+        (bytes memory ctx,) = ep.simulateValidate(address(paymaster), op, 0);
+        ep.simulatePostOp{value: 1 ether}(address(paymaster), ctx, 0.5 ether);
+        assertEq(ep.deposits(address(paymaster)), 0.5 ether);
+    }
+
+    function testNonWhitelistedReverts() public {
+        UserOperation memory op = _buildOp();
+        vm.expectRevert();
+        ep.simulateValidate(address(paymaster), op, 0);
+    }
+
+    function testGasSponsoredEvent() public {
+        paymaster.addToWhitelist(originAddr);
+        UserOperation memory op = _buildOp();
+        (bytes memory ctx,) = ep.simulateValidate(address(paymaster), op, 0);
+        ep.simulatePostOp{value: 0}(address(paymaster), ctx, 123);
+        assertEq(paymaster.lastUser(), user);
+        assertEq(paymaster.lastAmount(), 123);
+    }
+
+    function testDepositToEntryPoint() public {
+        paymaster.depositToEntryPoint{value: 1 ether}();
+        assertEq(ep.deposits(address(paymaster)), 1 ether);
+    }
+
+    function testRemoveFromWhitelist() public {
+        paymaster.addToWhitelist(originAddr);
+        paymaster.removeFromWhitelist(originAddr);
+        UserOperation memory op = _buildOp();
+        vm.expectRevert();
+        ep.simulateValidate(address(paymaster), op, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add ZfaPaymaster contract inheriting from OpenZeppelin BasePaymaster
- support dApp whitelisting and deposit refunds
- test SmartAccount and ZfaPaymaster behaviour
- document paymaster architecture

## Testing
- `make ci`
- `forge test`
